### PR TITLE
Fix 3 temperature.py regressions from May 19 refactor

### DIFF
--- a/its-a-plane-python/utilities/temperature.py
+++ b/its-a-plane-python/utilities/temperature.py
@@ -31,6 +31,51 @@ except (ModuleNotFoundError, NameError, ImportError):
 if TEMPERATURE_UNITS not in ("metric", "imperial"):
     TEMPERATURE_UNITS = "metric"
 
+# ─── Persistent File Cache (shared — both master and slave use this) ─────────
+_CACHE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".cache")
+os.makedirs(_CACHE_DIR, exist_ok=True)
+_TEMP_CACHE_FILE     = os.path.join(_CACHE_DIR, "temperature.json")
+_FORECAST_CACHE_FILE = os.path.join(_CACHE_DIR, "forecast.json")
+_CACHE_TTL           = 7200  # 2 hours — use file cache if API fails within this window
+
+# ─── Invalidate caches if units have changed ──────────────────────────────────
+def _invalidate_on_units_change():
+    for path in (_TEMP_CACHE_FILE, _FORECAST_CACHE_FILE):
+        try:
+            with open(path, "r") as f:
+                obj = json.load(f)
+            if obj.get("units") != TEMPERATURE_UNITS:
+                logging.info(f"[Weather] Units changed, deleting stale cache: {path}")
+                os.remove(path)
+        except (FileNotFoundError, json.JSONDecodeError):
+            pass
+
+_invalidate_on_units_change()
+
+def _load_file_cache(path, units=None):
+    """Load cached data from file. Returns (data, timestamp) or (None, 0).
+    If `units` is provided and doesn't match what's stored, treats cache as a miss
+    so a units change (metric <-> imperial) always triggers a fresh API call."""
+    try:
+        with open(path, "r") as f:
+            obj = json.load(f)
+        if units is not None and obj.get("units") != units:
+            logging.info(f"Cache units mismatch ({obj.get('units')!r} -> {units!r}), invalidating {path}")
+            return None, 0
+        return obj.get("data"), obj.get("ts", 0)
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return None, 0
+
+def _save_file_cache(path, data, units=None):
+    """Save data + timestamp (+ units) to file cache (atomic via rename)."""
+    try:
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump({"data": data, "ts": time.time(), "units": units}, f)
+        os.replace(tmp, path)  # atomic on POSIX
+    except (PermissionError, OSError) as e:
+        logging.warning(f"Cannot write cache {path}: {e}")
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # SLAVE MODE — poll weather data from the master Pi
@@ -40,9 +85,12 @@ if MASTER_TRACKER:
     from requests.exceptions import RequestException
 
     def _url(path):
-        host = MASTER_TRACKER.rstrip("/")
+        host = MASTER_TRACKER.strip().rstrip("/")
         if not host.startswith("http"):
-            host = f"http://{host}.local:8080"
+            if ":" not in host:
+                host = f"http://{host}.local:8080"
+            else:
+                host = f"http://{host}"
         return f"{host}{path}"
 
     def grab_temperature_and_humidity():
@@ -56,9 +104,14 @@ if MASTER_TRACKER:
             if temperature is None or humidity is None:
                 logging.warning("[Slave/Weather] Master returned incomplete temp/humidity data")
                 return None, None
+            _save_file_cache(_TEMP_CACHE_FILE, [temperature, humidity], units=TEMPERATURE_UNITS)
             return temperature, humidity
         except RequestException as e:
             logging.error(f"[Slave/Weather] Cannot reach master for weather: {e}")
+            cached, ts = _load_file_cache(_TEMP_CACHE_FILE, units=TEMPERATURE_UNITS)
+            if cached and (time.time() - ts) < _CACHE_TTL:
+                logging.info("[Slave/Weather] Using cached temperature data")
+                return tuple(cached) if isinstance(cached, list) else cached
             return None, None
 
     def grab_forecast(tag="unknown"):
@@ -71,9 +124,14 @@ if MASTER_TRACKER:
             if not isinstance(forecast, list):
                 logging.warning(f"[Slave/Weather:{tag}] Master returned non-list forecast")
                 return []
+            _save_file_cache(_FORECAST_CACHE_FILE, forecast, units=TEMPERATURE_UNITS)
             return forecast
         except RequestException as e:
             logging.error(f"[Slave/Weather:{tag}] Cannot reach master for forecast: {e}")
+            cached, ts = _load_file_cache(_FORECAST_CACHE_FILE, units=TEMPERATURE_UNITS)
+            if cached and (time.time() - ts) < _CACHE_TTL:
+                logging.info(f"[Slave/Weather:{tag}] Using cached forecast data")
+                return cached
             return []
 
     print(f"[Weather] Slave mode — polling master at {_url('')}")
@@ -95,52 +153,10 @@ else:
     except (ModuleNotFoundError, NameError, ImportError):
         TOMORROW_API_KEY = None
 
-    from config import TEMPERATURE_LOCATION
-
-    # ─── Persistent File Cache ────────────────────────────────────────────────
-    _CACHE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".cache")
-    os.makedirs(_CACHE_DIR, exist_ok=True)
-    _TEMP_CACHE_FILE     = os.path.join(_CACHE_DIR, "temperature.json")
-    _FORECAST_CACHE_FILE = os.path.join(_CACHE_DIR, "forecast.json")
-    _CACHE_TTL           = 7200  # 2 hours — use file cache if API fails within this window
-    
-    # ─── Invalidate caches if units have changed ──────────────────────────────
-    def _invalidate_on_units_change():
-        for path in (_TEMP_CACHE_FILE, _FORECAST_CACHE_FILE):
-            try:
-                with open(path, "r") as f:
-                    obj = json.load(f)
-                if obj.get("units") != TEMPERATURE_UNITS:
-                    logging.info(f"[Weather] Units changed, deleting stale cache: {path}")
-                    os.remove(path)
-            except (FileNotFoundError, json.JSONDecodeError):
-                pass
-
-    _invalidate_on_units_change()
-
-    def _load_file_cache(path, units=None):
-        """Load cached data from file. Returns (data, timestamp) or (None, 0).
-        If `units` is provided and doesn't match what's stored, treats cache as a miss
-        so a units change (metric ↔ imperial) always triggers a fresh API call."""
-        try:
-            with open(path, "r") as f:
-                obj = json.load(f)
-            if units is not None and obj.get("units") != units:
-                logging.info(f"Cache units mismatch ({obj.get('units')!r} → {units!r}), invalidating {path}")
-                return None, 0
-            return obj.get("data"), obj.get("ts", 0)
-        except (FileNotFoundError, json.JSONDecodeError, KeyError):
-            return None, 0
-
-    def _save_file_cache(path, data, units=None):
-        """Save data + timestamp (+ units) to file cache (atomic via rename)."""
-        try:
-            tmp = path + ".tmp"
-            with open(tmp, "w") as f:
-                json.dump({"data": data, "ts": time.time(), "units": units}, f)
-            os.replace(tmp, path)  # atomic on POSIX
-        except (PermissionError, OSError) as e:
-            logging.warning(f"Cannot write cache {path}: {e}")
+    try:
+        from config import TEMPERATURE_LOCATION
+    except (ImportError, NameError):
+        TEMPERATURE_LOCATION = ""
 
     def is_dns_error(exc: Exception) -> bool:
         cause = exc


### PR DESCRIPTION
## Summary

The May 19 temperature.py refactor (master/slave split) introduced three regressions. The units-aware cache and DNS detection additions are great improvements -- these fixes preserve all of that while restoring three things that broke.

### Bug 1: Slave file cache removed

The persistent file cache infrastructure (`_load_file_cache`, `_save_file_cache`, cache constants) was moved inside the `else:` (master-only) branch. Slaves lost their 2-hour cache resilience -- if the master goes down, they immediately return `None` instead of serving cached data.

**Fix:** Move cache constants and functions to module level (before the `if MASTER_TRACKER:` / `else:` branch) so both modes share them. Added `_save_file_cache()` calls on successful slave fetches and `_load_file_cache()` fallback in the `except` blocks.

### Bug 2: `_url()` port detection removed

Current code unconditionally appends `.local:8080` when the host doesn't start with `http`. This breaks `MASTER_TRACKER="hostname:9090"` -- it becomes `http://hostname:9090.local:8080`.

**Fix:** Check for `:` in the host string before appending default port, so explicit ports like `hostname:9090` become `http://hostname:9090` while bare hostnames like `myhost` still get `.local:8080`.

### Bug 3: Bare `TEMPERATURE_LOCATION` import

`from config import TEMPERATURE_LOCATION` (line 98) has no `try/except` guard. Crashes on any setup that doesn't define this variable in config.py.

**Fix:** Wrap in `try/except (ImportError, NameError)` with empty string fallback, matching the pattern used for all other config imports in this file.

## Changes

- 1 file changed: `its-a-plane-python/utilities/temperature.py`
- Net: moved cache infra up ~30 lines, added 3 guard lines, added ~10 lines of slave cache read/write

## Test plan

- [ ] Master mode: verify temperature and forecast still fetch from Tomorrow.io and write cache files
- [ ] Slave mode: verify slave fetches from master and writes cache files
- [ ] Slave mode: stop master, verify slave falls back to cached data for up to 2 hours
- [ ] Set `MASTER_TRACKER="hostname:9090"` -- verify URL resolves to `http://hostname:9090`
- [ ] Set `MASTER_TRACKER="myhost"` -- verify URL resolves to `http://myhost.local:8080`
- [ ] Remove `TEMPERATURE_LOCATION` from config.py -- verify no crash on startup

Generated with [Claude Code](https://claude.com/claude-code)