### PR TITLE
Fix scroll sync: shared position for both text lines

### DIFF
--- a/its-a-plane-python/display/__init__.py
+++ b/its-a-plane-python/display/__init__.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime
-from setup import frames
+from setup import frames, screen
 from utilities.animator import Animator
 from utilities.overhead import Overhead
 
@@ -28,7 +28,8 @@ def flight_updated(flights_a, flights_b):
     return updatable_a == updatable_b
 
 
-SCROLL_REGIONS = ("flight_details", "plane_details")
+# Scroll sync: single shared position for both text lines.
+# Both lines scroll together; the wider one determines when to reset/advance.
 
 
 try:
@@ -109,7 +110,9 @@ class Display(
 
         self._data_index = 0
         self._data = []
-        self._scroll_complete = {region: False for region in SCROLL_REGIONS}
+        self._data_all_looped = False
+        self._scroll_pos = screen.WIDTH
+        self._scroll_widths = {}  # region -> text width in pixels
 
         # Single Overhead instance handles both zone and tracked flight
         self.overhead = Overhead()
@@ -123,12 +126,9 @@ class Display(
         for x in range(x0, x1):
             _ = graphics.DrawLine(self.canvas, x, y0, x, y1, colour)
 
-    def mark_scroll_complete(self, region):
-        if region in self._scroll_complete:
-            self._scroll_complete[region] = True
-
-    def reset_scroll_completion(self):
-        self._scroll_complete = {region: False for region in SCROLL_REGIONS}
+    def report_scroll_width(self, region, width):
+        """Called by each scroll scene to report its text width."""
+        self._scroll_widths[region] = width
 
     @Animator.KeyFrame.add(0)
     def clear_screen(self):
@@ -144,7 +144,8 @@ class Display(
             if data_is_different:
                 self._data_index = 0
                 self._data_all_looped = False
-                self.reset_scroll_completion()
+                self._scroll_pos = screen.WIDTH
+                self._scroll_widths = {}
                 self._data = new_data
 
             reset_required = there_is_data and data_is_different
@@ -153,15 +154,25 @@ class Display(
                 self.reset_scene()
 
     @Animator.KeyFrame.add(1)
-    def advance_completed_scroll(self, count):
-        if len(self._data) <= 1:
+    def advance_scroll(self, count):
+        """Single scroll driver for all text lines. Both lines share one position."""
+        if len(self._data) == 0:
             return
 
-        if all(self._scroll_complete.values()):
-            self._data_index = (self._data_index + 1) % len(self._data)
-            self._data_all_looped = self._data_index == 0 or self._data_all_looped
-            self.reset_scroll_completion()
-            self.reset_scene()
+        # Decrement shared position
+        self._scroll_pos -= 1
+
+        # Check if widest text has fully scrolled off screen
+        if not self._scroll_widths:
+            return
+        max_width = max(self._scroll_widths.values())
+        if self._scroll_pos + max_width < 0:
+            if len(self._data) > 1:
+                self._data_index = (self._data_index + 1) % len(self._data)
+                self._data_all_looped = self._data_index == 0 or self._data_all_looped
+                self._scroll_widths = {}
+                self.reset_scene()
+            self._scroll_pos = screen.WIDTH
 
     @Animator.KeyFrame.add(1)
     def sync(self, count):

--- a/its-a-plane-python/scenes/flightdetails.py
+++ b/its-a-plane-python/scenes/flightdetails.py
@@ -21,19 +21,12 @@ DATA_INDEX_COLOUR = colours.GREY
 class FlightDetailsScene(object):
     def __init__(self):
         super().__init__()
-        self.flight_position = screen.WIDTH
-        self.flight_details_complete = False
-        self._data_all_looped = False
 
     @Animator.KeyFrame.add(1)
     def flight_details(self, count):
 
         # Guard against no data
         if len(self._data) == 0:
-            return
-
-        # Skip rendering after scroll complete (waiting for other regions)
-        if self.flight_details_complete:
             return
 
         # Clear the whole area
@@ -66,7 +59,7 @@ class FlightDetailsScene(object):
                 ch_length = graphics.DrawText(
                     self.canvas,
                     FLIGHT_NO_FONT,
-                    self.flight_position + flight_no_text_length,
+                    self._scroll_pos + flight_no_text_length,
                     FLIGHT_NO_DISTANCE_FROM_TOP,
                     FLIGHT_NUMBER_NUMERIC_COLOUR
                     if ch.isnumeric()
@@ -96,21 +89,12 @@ class FlightDetailsScene(object):
                 f"{self._data_index + 1}/{len(self._data)}",
             )
 
-            # Count the whole line length
-            flight_no_text_length += text_length
+            # Fixed position indicator — don't add to scroll width
 
-        # Handle scrolling
-        self.flight_position -= 1
-        if self.flight_position + flight_no_text_length < 0:
-            if len(self._data) > 1:
-                # Mark complete and wait for other regions
-                self.flight_details_complete = True
-                self.mark_scroll_complete("flight_details")
-            else:
-                self.flight_position = screen.WIDTH
+        # Report width to shared scroll driver
+        self.report_scroll_width("flight_details", flight_no_text_length)
 
     @Animator.KeyFrame.add(0)
     def reset_flight_details_scroll(self):
-        self.flight_position = screen.WIDTH
-        self.flight_details_complete = False
+        pass  # Called by reset_scene(); scroll position owned by Display._scroll_pos
 

--- a/its-a-plane-python/scenes/planedetails.py
+++ b/its-a-plane-python/scenes/planedetails.py
@@ -75,9 +75,6 @@ def _build_char_list(plane_name, distance, direction, altitude, vertical_speed, 
 class PlaneDetailsScene(object):
     def __init__(self):
         super().__init__()
-        self.plane_position = screen.WIDTH
-        self.plane_details_complete = False
-        self._data_all_looped = False
 
     @Animator.KeyFrame.add(1)
     def plane_details(self, count):
@@ -115,25 +112,16 @@ class PlaneDetailsScene(object):
             w = graphics.DrawText(
                 self.canvas,
                 PLANE_FONT,
-                self.plane_position + total_text_width,
+                self._scroll_pos + total_text_width,
                 PLANE_DISTANCE_FROM_TOP,
                 colour,
                 ch,
             )
             total_text_width += w
 
-        # Handle scrolling
-        self.plane_position -= 1
-
-        # Mark scroll complete when text scrolls off (wait for other regions)
-        if self.plane_position + total_text_width < 0:
-            if len(self._data) > 1:
-                self.plane_details_complete = True
-                self.mark_scroll_complete("plane_details")
-            else:
-                self.plane_position = screen.WIDTH
+        # Report width to shared scroll driver
+        self.report_scroll_width("plane_details", total_text_width)
 
     @Animator.KeyFrame.add(0)
     def reset_plane_details_scroll(self):
-        self.plane_position = screen.WIDTH
-        self.plane_details_complete = False
+        pass  # Called by reset_scene(); scroll position owned by Display._scroll_pos


### PR DESCRIPTION
Fixes two visual bugs with the two scrolling text lines (flight details + plane details):

1. **Lines start at different positions** — different text widths cause them to reset independently, so they drift apart
2. **Premature advance to next flight** — the shorter line finishes scrolling and marks complete before the longer one is done

**Fix:** Both lines now share a single scroll position (`Display._scroll_pos`). The wider text determines when to reset/advance. Removes per-scene scroll state, `mark_scroll_complete`, and `SCROLL_REGIONS`.

Tested on 3 devices.