### PR TITLE
Add UCA (CommuteAir) to United Express overrides

### DIFF
--- a/its-a-plane-python/utilities/airlines.py
+++ b/its-a-plane-python/utilities/airlines.py
@@ -22,6 +22,7 @@ _OVERRIDES = {
     # United Express operators
     "GJS": "United Express",   "CPZ": "United Express",
     "ASH": "United Express",   "G7":  "United Express",
+    "UCA": "United Express",
     # Delta Connection operators
     "EDV": "Delta Connection", "ASQ": "Delta Connection",
     # Dual-brand (brand resolved by FlightStats/AirLabs per flight)


### PR DESCRIPTION
CommuteAir ceased operations in 2023 but planes still fly under UCA callsigns as United Express regionals (e.g. UCA4828 IAD->PVD). Without this, the display shows 'CommutAir' instead of 'United Express'.

Spotted on a test device — these IAD->PVD E45X flights pass over regularly.