### PR TITLE
Fix OOM crash: guard thread accumulation in grab_data()

### DIFF
--- a/its-a-plane-python/utilities/overhead.py
+++ b/its-a-plane-python/utilities/overhead.py
@@ -79,12 +79,15 @@ if MASTER_TRACKER:
             print(f"[Overhead] Slave mode — polling master at {_url('')}")
 
         def grab_data(self):
+            with self._lock:
+                if self._processing:
+                    return
+                self._processing = True
             Thread(target=self._grab, daemon=True).start()
 
         def _grab(self):
             with self._lock:
                 self._new_data = False
-                self._processing = True
             try:
                 r = requests.get(_url("/overhead/json"), timeout=10)
                 r.raise_for_status()
@@ -458,12 +461,15 @@ else:
                 self._tracked_just_airborne   = False # True for one cycle after first airborne detection
 
             def grab_data(self):
+                with self._lock:
+                    if self._processing:
+                        return
+                    self._processing = True
                 Thread(target=self._grab, daemon=True).start()
 
             def _grab(self):
                 with self._lock:
                     self._new_data   = False
-                    self._processing = True
 
                 self._fr24._last_source = None
                 overhead_data = []


### PR DESCRIPTION
## Bug: OOM crash from thread accumulation

Both the master and slave `Overhead` classes spawn a new `Thread` on every `grab_data()` call with no check for whether a previous `_grab` is still running. When API calls hang or are slow, threads pile up unbounded — each holding MB of response data — until the OOM killer fires (exit code -9) on a 416MB Pi, causing a crash loop.

## Fix

Check `_processing` flag under lock before spawning:

```python
# BEFORE:
def grab_data(self):
    Thread(target=self._grab, daemon=True).start()

# AFTER:
def grab_data(self):
    with self._lock:
        if self._processing:
            return
        self._processing = True
    Thread(target=self._grab, daemon=True).start()
```

Applied to both master and slave `Overhead` classes. The `_processing` flag is already cleared in `finally` blocks, so the next grab proceeds normally.

This was causing one of my Pi devices to enter an OOM crash loop. All 3 are stable since the fix (~5 hours, 490+ cycles each).