### PR TITLE
Cap glibc malloc arenas in the service file (fixes slow memory creep + scroll stutter on 512MB Pis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,8 +465,10 @@ EOF
 > is a heap that ratchets upward for days. On a 512MB Pi it eventually pushes
 > the tracker into SD-card swap, and because swap is that slow, the scroll
 > visibly freezes for a second or two at a time. Capping the arenas keeps the
-> heap compact enough to actually reclaim. It's a no-op on Pis with more RAM,
-> so it's safe to leave in either way.
+> heap compact enough to actually reclaim. On Pis with more RAM it's effectively
+> free — capping arenas can add a little malloc lock contention in heavily
+> multithreaded native code, but this workload is GIL-bound with one short-lived
+> poll thread — so it's safe to leave in either way.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ After=network.target
 [Service]
 User=$(whoami)
 WorkingDirectory=$HOME
+Environment=MALLOC_ARENA_MAX=2
 ExecStart=$(pwd)/its-a-plane.py
 Restart=always
 RestartSec=10
@@ -454,6 +455,18 @@ EOF
 ```
 
 > ⚠️ **Important:** Run the `cd` command first or the paths will be wrong!
+
+> 💡 **`MALLOC_ARENA_MAX=2`** keeps memory from creeping up on small Pis. The
+> overhead poll starts a fresh thread each cycle (`utilities/overhead.py`) that
+> does an HTTP fetch and exits. glibc gives every new thread its own malloc
+> arena (default ceiling `8 × nproc`), so those per-poll allocations get spread
+> across arenas — freed blocks end up interleaved with live ones, and the
+> allocator can only hand memory back to the OS in fully-free pages. The result
+> is a heap that ratchets upward for days. On a 512MB Pi it eventually pushes
+> the tracker into SD-card swap, and because swap is that slow, the scroll
+> visibly freezes for a second or two at a time. Capping the arenas keeps the
+> heap compact enough to actually reclaim. It's a no-op on Pis with more RAM,
+> so it's safe to leave in either way.
 
 ---
 


### PR DESCRIPTION
Adds one line — `Environment=MALLOC_ARENA_MAX=2` — to the service file in step 12, plus a short note explaining it.

### The symptom

On a 512MB Pi the tracker gets gradually slower over days of uptime, and the scroll starts freezing for a second or two at a time. Restarting the service clears it, and then it slowly comes back.

### What's actually happening

It looks like a memory leak but it isn't one. The overhead poll starts a **fresh thread every cycle** (`utilities/overhead.py:82` and `:464`) that does its HTTP fetch and exits. glibc hands each new thread its own malloc arena — the default ceiling is `8 × nproc`, so 24 arenas on a Pi 3. Each cycle's allocations land in whichever arena that thread happened to get, freed blocks end up interleaved with live ones, and `malloc_trim()` can then only return pages that are *completely* free. So the heap ratchets upward even though nothing is being retained.

Once RSS outgrows RAM the Pi starts swapping, and since swap is on the SD card, the scroll animation stalls whenever it touches a paged-out region. That's the freeze.

### Measurements

From a Pi 3A+ (512MB) running this lineage, after ~2 days uptime:

| | before | after the cap |
|---|---|---|
| heap (`VmData`) | 278MB, still climbing | plateaus ~240MB |
| resident (`VmRSS`) | 123MB | — |
| true footprint (`VmRSS+VmSwap`) | ratcheting ~2-4 MB/h | **−0.31 MB/h over 18h**, 7.9MB spread |
| swap-ins (`/proc/vmstat pswpin`) | thrashing | ~3 pages/min |

The 278MB-heap-vs-123MB-resident gap is the tell: that's fragmentation, not objects being held. I checked the caches in this tree and they're all bounded, and I ran the poll cycle repeatedly under `tracemalloc` — Python object counts, gc, and fds all stay flat.

After capping arenas, the footprint goes flat and the remaining swapped pages stay cold (never read back), so the stall mechanism is gone. Running on three Pis now.

### Why the README and not a code change

`MALLOC_ARENA_MAX` has to be set before the process starts, so the service file is the natural home. It's a no-op on Pis with more RAM, so it's harmless for everyone else.

### One gotcha worth knowing

If anyone's `ExecStart` invokes python through `sudo`, this won't reach the app — sudo's `env_reset` strips it. In that case it has to be passed as a `sudo MALLOC_ARENA_MAX=2 ...` argument instead. The service file in step 12 runs the script directly, so `Environment=` is fine here.
